### PR TITLE
fix(css): configure Tailwind/PostCSS to restore styles in production

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,7 +1,7 @@
 /* Global Styles and Theme System */
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* CSS Reset and Base Styles */
 * {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './public/index.html',
+    './src/**/*.{js,jsx,ts,tsx,html}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [
+    require('@tailwindcss/forms')
+  ]
+};
+


### PR DESCRIPTION
Summary

Production build rendered unstyled HTML because Tailwind CSS wasn’t being processed. This PR adds the required Tailwind/PostCSS configuration and switches from `@import 'tailwindcss/*'` to `@tailwind` directives.

Changes
- frontend/tailwind.config.js: add config, darkMode='class', content paths
- frontend/postcss.config.js: enable tailwindcss + autoprefixer
- frontend/src/styles/globals.css: replace @import with @tailwind base/components/utilities

Notes
- No visual regressions expected beyond restoring intended styling
- Dark mode continues to rely on the `dark` class on <html> (already handled earlier)

No emojis used.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author